### PR TITLE
Add d parameter

### DIFF
--- a/examples/example 1 - loading and using bootstrap action from resample.sas
+++ b/examples/example 1 - loading and using bootstrap action from resample.sas
@@ -14,5 +14,11 @@ proc cas;
 	resample.bootstrap / intable='sample' B=100;
 	*resample.doubleBootstrap / intable='sample' B=100;
 run;
+/*
+test bs first
+test dbs after bs
+test dbs without bs first
+*/
+
 
 *cas mysess clear;

--- a/examples/example 1 - loading and using bootstrap action from resample.sas
+++ b/examples/example 1 - loading and using bootstrap action from resample.sas
@@ -11,14 +11,70 @@ quit;
 */
 proc cas;
 	builtins.actionSetFromTable / table={caslib="Public" name="resampleActionSet.sashdat"} name="resample";
-	resample.bootstrap / intable='sample' B=100;
-	*resample.doubleBootstrap / intable='sample' B=100;
 run;
-/*
-test bs first
-test dbs after bs
-test dbs without bs first
-*/
 
+/* bootstrap */
+proc cas;
+	resample.bootstrap / intable='sample' B=100;
+			/*  take a look at how the table is distributed in the CAS environment */
+			datastep.runcode result=t / code='data sample_bs; set sample_bs; host=_hostname_; threadid=_threadid_; run;';
+			simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="threadid" aggregator="N";
+run;
 
+/* double-bootstrap after bootstrap */
+proc cas;
+	resample.doubleBootstrap / intable='sample' B=100 D=10;
+			/*  take a look at how the table is distributed in the CAS environment */
+			datastep.runcode result=t / code='data sample_dbs; set sample_dbs; host=_hostname_; threadid=_threadid_; run;';
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="threadid" aggregator="N";
+run;
+
+/* double-bootstrap after bootstrap - give wrong B? (it gets ignorned because it detects B from prior bootstrap) */
+proc cas;
+	resample.doubleBootstrap / intable='sample' B=10 D=10;
+			/*  take a look at how the table is distributed in the CAS environment */
+			datastep.runcode result=t / code='data sample_dbs; set sample_dbs; host=_hostname_; threadid=_threadid_; run;';
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="threadid" aggregator="N";
+run;
+
+/* double-bootstrap without first running bootstrap */
+proc cas;
+	dropTable name="sample_bs";
+	dropTable name="sample_dbs";
+	resample.doubleBootstrap / intable='sample' B=100 D=10;
+			/*  take a look at how the table is distributed in the CAS environment */
+			datastep.runcode result=t / code='data sample_bs; set sample_bs; host=_hostname_; threadid=_threadid_; run;';
+			simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="threadid" aggregator="N";
+			datastep.runcode result=t / code='data sample_dbs; set sample_dbs; host=_hostname_; threadid=_threadid_; run;';
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="host" aggregator="N";
+			simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="threadid" aggregator="N";
+run;
+
+/* different size double-bootstrap */
+proc cas;
+		dropTable name="sample_bs";
+		dropTable name="sample_dbs";
+		resample.doubleBootstrap / intable='sample' B=100 D=100;
+				/*  take a look at how the table is distributed in the CAS environment */
+				datastep.runcode result=t / code='data sample_bs; set sample_bs; host=_hostname_; threadid=_threadid_; run;';
+				simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="host" aggregator="N";
+				simple.crossTab / table={name="sample_bs" where="bag=1"} row="bsid" col="threadid" aggregator="N";
+				datastep.runcode result=t / code='data sample_dbs; set sample_dbs; host=_hostname_; threadid=_threadid_; run;';
+				simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+				simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+				simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="host" aggregator="N";
+				simple.crossTab / table={name="sample_dbs" where="bag=1 and bsid=128"} row="dbsid" col="threadid" aggregator="N";
+run;
+
+quit;
 *cas mysess clear;

--- a/examples/example 3 - regression double-bootstrap parameter estimates.sas
+++ b/examples/example 3 - regression double-bootstrap parameter estimates.sas
@@ -55,7 +55,7 @@ run;
 /* create double-bootstraped resamples */
 proc cas;
 	builtins.actionSetFromTable / table={caslib="Public" name="resampleActionSet.sashdat"} name="resample";
-	resample.doubleBootstrap / intable='sample' B=50;
+	resample.doubleBootstrap / intable='sample' B=50 D=10;
 run;
 
 /* analyze/train each bootstrap resample with the same model effects selected on the full sample data */

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ For an acknowledgement of the importance of the bootstrap, a great place to star
 ## Notes about code
 All code is written in SAS CASL which can be executed from a SAS interface with PROC CAS or from the various (Python, R, REST,...) API's.  As of SAS Viya version 3.4 there is not a packaged bootstrap action.  This repository has a user defined action set and instructions for loading it in your environment.  This also makes a great example of how to easily extend the capabilities of SAS Viya and share with all users in your environment.
 
+## Contribute
+Have something to add?  Just fork it, change it, and create a pull request!
+
+Have comments, questions, suggestions? Just use the issues feature
+
 ## Contents of the repository
 * [resample - defineActionSet.sas](./resample%20-%20defineActionSet.sas)
 * Folder: [examples](./examples) contains examples of using the actions
@@ -35,6 +40,7 @@ To use the actions you will need to load the user defined actions with:
 ```SAS
 builtins.actionSetFromTable / table={caslib="Public" name="resampleActionSet.sashdat"} name="resample";
 ```
+# Syntax Reference
 ---
 ### resample.addRowID action
 Updates the provided table <intable> with a new column named RowID that has a naturally numbered (1,2,...,n) across the distributed in-memory table.
@@ -53,10 +59,10 @@ Parameter Descriptions
 
 ---
 ### resample.bootstrap action
-Creates a table of identically sized bootstrap resamples from table <intable> and stores them in a table named <intable>_bs.  Runs the addRowID action on the <intable>.  Columns that describe the link between the bootstrap resamples and the original sample are:
+Creates a table of identically sized bootstrap resamples from table `<intable>` and stores them in a table named `<intable>_bs`.  Runs the addRowID action on the `<intable>`.  Columns that describe the link between the bootstrap resamples and the original sample are:
 * bsID - is the naturally numbered (1, 2, ..., b) identifier of a resample
 * bs_rowID - is the naturally numbered (1, 2, ..., n) row identifier within the value of bsID
-* rowID - is the naturally numbered (1, 2, ..., n) row identifier for the sampled row in <intable>
+* rowID - is the naturally numbered (1, 2, ..., n) row identifier for the sampled row in `<intable>`
 * bag - is 1 for resampled rows, 0 for rowID values not resampled within the bsID (will have missing for bs_rowID)
 
 ```
@@ -79,12 +85,12 @@ Parameter Descriptions
 
 ---
 ### resample.doubleBootstrap action
-Creates a table of identically sized bootstrap and double-bootstrap resamples from table <intable> and stores them in tables <intable>_bs and <intable>_dbs.  Runs the addRowID action on the <intable>.  If the bootstrap action has already been run on table <intable> then a table <intable>_bs already exist and will be used for double-bootstraping.  Columns that describe the link between the double-bootstrap resamples and the bootstrap resamples are:
+Creates a table of identically sized bootstrap and double-bootstrap resamples from table `<intable>` and stores them in tables `<intable>_bs` and `<intable>_dbs`.  Runs the addRowID action on the `<intable>`.  If the bootstrap action has already been run on table `<intable>` then a table `<intable>_bs` already exist and will be used for double-bootstraping.  Columns that describe the link between the double-bootstrap resamples and the bootstrap resamples are:
 * bsID - is the naturally numbered (1, 2, ..., b) identifier of a resample
 * dbsID - is the naturally numbered (1, 2, ..., d) identifier of a resample from a bsID
 * dbs_rowID - is the naturally numbered (1, 2, ..., n) row identifier within the value of dbsID
 * bs_rowID - is the naturally numbered (1, 2, ..., n) row identifier for the resampled row in bsID
-* rowID - is the naturally numbered (1, 2, ..., n) row identifier for the resampled row in <intable>
+* rowID - is the naturally numbered (1, 2, ..., n) row identifier for the resampled row in `<intable>`
 * bag - is 1 for resampled rows, 0 for rowID values not resampled within the bsID (will have missing for bs_rowID)
   * 0 could be a non-resampled row in either the bsID or the dbsID (resampled from bsID)
 
@@ -112,7 +118,3 @@ Parameter Descriptions
     Note: The number of double-bootstrap resamples is atleast B*D.  For Example: B=1000 and D=1000 yields at least B*D=1000000
 ```
 ---
-## Contribute
-Have something to add?  Just fork it, change it, and create a pull request!
-
-Have comments, questions, suggestions? Just use the issues feature

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Run the code in [resample - defineActionSet.sas](./resample%20-%20defineActionSe
   * line 133: removes the persisted in-memory table
 
 ## Actions Instructions
-To use the actions you will need to load the user define actions with:
+To use the actions you will need to load the user defined actions with:
 ```SAS
 builtins.actionSetFromTable / table={caslib="Public" name="resampleActionSet.sashdat"} name="resample";
 ```
@@ -73,12 +73,13 @@ Parameter Descriptions
       specifies the name of the table to resample from in CAS
     B=integer
       required
-      Specifies the desired number of bootstrap resamples.  Will look at the number of threads (_nthreads_) in the environment and set the value of bss (resamples per _threadid_) to ensure the final number of bootstrap resamples is >=B.
+      Specifies the desired number of bootstrap resamples.  
+        Will look at the number of threads (_nthreads_) in the environment and set the value of bss (resamples per _threadid_) to ensure the final number of bootstrap resamples is >=B.
 ```
 
 ---
 ### resample.doubleBootstrap action
-Creates a table of identically sized bootstrap and double-bootstrap resamples from table <intable> and stores them in a tables <intable>_bs and <intable>_dbs.  Runs the addRowID action on the <intable>.  Columns that describe the link between the double-bootstrap resamples and the bootstrap resamples are:
+Creates a table of identically sized bootstrap and double-bootstrap resamples from table <intable> and stores them in tables <intable>_bs and <intable>_dbs.  Runs the addRowID action on the <intable>.  If the bootstrap action has already been run on table <intable> then a table <intable>_bs already exist and will be used for double-bootstraping.  Columns that describe the link between the double-bootstrap resamples and the bootstrap resamples are:
 * bsID - is the naturally numbered (1, 2, ..., b) identifier of a resample
 * dbsID - is the naturally numbered (1, 2, ..., d) identifier of a resample from a bsID
 * dbs_rowID - is the naturally numbered (1, 2, ..., n) row identifier within the value of dbsID
@@ -103,7 +104,7 @@ Parameter Descriptions
     B=integer
       required
       Specifies the desired number of bootstrap resamples.  Will look at the number of threads (_nthreads_) in the environment and set the value of bss (resamples per _threadid_) to ensure the final number of bootstrap resamples is >=B.
-      If you run resample.bootstrap first then make sure you used the same value of B.
+      If you run resample.bootstrap first then you should use the same value of B (it will ignore the value and use the value from the prior bootstrap).
           If you don't run resample.bootstrap first then resample.doubleBootstrap will do it correctly.
     D=integer
       required

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Parameter Descriptions
 ### resample.doubleBootstrap action
 Creates a table of identically sized bootstrap and double-bootstrap resamples from table <intable> and stores them in a tables <intable>_bs and <intable>_dbs.  Runs the addRowID action on the <intable>.  Columns that describe the link between the double-bootstrap resamples and the bootstrap resamples are:
 * bsID - is the naturally numbered (1, 2, ..., b) identifier of a resample
-* dbsID - is the naturally numbered (1, 2, ..., b) identifier of a resample from bsID
+* dbsID - is the naturally numbered (1, 2, ..., d) identifier of a resample from a bsID
 * dbs_rowID - is the naturally numbered (1, 2, ..., n) row identifier within the value of dbsID
 * bs_rowID - is the naturally numbered (1, 2, ..., n) row identifier for the resampled row in bsID
 * rowID - is the naturally numbered (1, 2, ..., n) row identifier for the resampled row in <intable>
@@ -93,6 +93,7 @@ CASL Syntax
     resample.doubleBootstrap /
       intable="string"
       B=integer
+      D=integer
 
 Parameter Descriptions
 
@@ -102,10 +103,12 @@ Parameter Descriptions
     B=integer
       required
       Specifies the desired number of bootstrap resamples.  Will look at the number of threads (_nthreads_) in the environment and set the value of bss (resamples per _threadid_) to ensure the final number of bootstrap resamples is >=B.
-      The number of double-bootstrap resamples per bootstrap resample will be the same as the number of bootstap resamples.  For example: if B=100 and _nthreads_=32 then the actual number of bootstrap resamples will be 4*32=128 (4 per _threadid_) and the number of double-bootstrap resamples will then be 128*128=16384.
       If you run resample.bootstrap first then make sure you used the same value of B.
           If you don't run resample.bootstrap first then resample.doubleBootstrap will do it correctly.
-
+    D=integer
+      required
+      Specifies the desired number of double-bootstrap resamples from each bootstrap resample.
+    Note: The number of double-bootstrap resamples is atleast B*D.  For Example: B=1000 and D=1000 yields at least B*D=1000000
 ```
 ---
 ## Contribute

--- a/resample - defineActionSet.sas
+++ b/resample - defineActionSet.sas
@@ -82,6 +82,7 @@ proc cas;
 				parms = {
 					{name="intable" type="string" required=TRUE}
 					{name="B" type="int" required=TRUE default=10}
+					{name="D" type="int" required=TRUE default=10}
 				}
 				definition = "
 							table.tableExists result=c / name=intable||'_bs';
@@ -100,7 +101,7 @@ proc cas;
 															  	call streaminit(12345);
 																do bs = 1 to '|| bss ||';
 																	bsID = (_threadid_-1)*'|| bss ||' + bs;
-																		do dbsID = 1 to '|| bss ||'*'|| q[1,1].M ||';
+																		do dbsID = 1 to '|| D ||';
 																			do dbs_rowID = 1 to '|| r.numrows ||';
 																	 			bs_rowID = int(1+'|| r.numrows ||'*rand(''Uniform''));
 																	 			bag=1;

--- a/resample - defineActionSet.sas
+++ b/resample - defineActionSet.sas
@@ -87,15 +87,18 @@ proc cas;
 				definition = "
 							table.tableExists result=c / name=intable||'_bs';
 								if c.exists then do;
-
+										/*calculate bss here*/
 								end;
 								else; do;
 									resample.bootstrap / intable=intable B=B;
+									/* will the bss carry through? */
 								end;
+								/*
 							datastep.runcode result=t / code='data tempholdb; nthreads=_nthreads_; output; run;';
 									fedsql.execDirect result=q / query='select max(nthreads) as M from tempholdb';
 									dropTable name='tempholdb';
 									bss=ceil(B/q[1,1].M);
+									*/
 							simple.numRows result=r / table=intable;
 							datastep.runcode result=t / code='data '|| intable ||'_dbskey;
 															  	call streaminit(12345);

--- a/walkthroughs/walkthrough - bootstrap action.sas
+++ b/walkthroughs/walkthrough - bootstrap action.sas
@@ -71,4 +71,14 @@ run;
     dropTable name=intable||'_bskey';
 quit;
 
+/* review the output table sample_bs */
+proc cas;
+/*
+how many bsID
+	how many bsID per _threadid_
+how many rows each (bag and OOB)
+*/
+run;
+
+
 *cas mysess clear;

--- a/walkthroughs/walkthrough - doubleBootstrap action.sas
+++ b/walkthroughs/walkthrough - doubleBootstrap action.sas
@@ -94,4 +94,14 @@ run;
 		dropTable name=intable||'_dbskey';
 quit;
 
+/* review the output table sample_dbs */
+proc cas;
+/*
+how many bsID
+	how many bsID per _threadid_
+how many dbsID in each
+how many rows in each dbsID (bag and OOB)
+*/
+run;
+
 *cas mysess clear;

--- a/walkthroughs/walkthrough - doubleBootstrap action.sas
+++ b/walkthroughs/walkthrough - doubleBootstrap action.sas
@@ -22,21 +22,24 @@ run;
 		/* check to see if resample.bootstrap has already been run
       		if not then run it first to get bootstrap resamples for double-bootstrap resampling */
 		builtins.actionSetFromTable / table={caslib="Public" name="resampleActionSet.sashdat"} name="resample";
-    table.tableExists result=c / name=intable||'_bs';
-      if c.exists then do;
-
-      end;
-      else; do;
-        resample.bootstrap / intable=intable B=B;
-      end;
-run;
-
-		/* use the datastep automatic variable nthreads to store the environment size (number of threads) in q[1,1].M
-				use this to calculate the value of bss - number of resamples per _threadid_ to achieve atleast B resamples */
-		datastep.runcode result=t / code='data tempholdb; nthreads=_nthreads_; output; run;';
-				fedsql.execDirect result=q / query='select max(nthreads) as M from tempholdb';
-				dropTable name='tempholdb';
-				bss=ceil(B/q[1,1].M);
+		table.tableExists result=c / name=intable||'_bs';
+			if c.exists then do;
+					/* calculate bss */
+					datastep.runcode result=t / code='data tempholdbss; set '|| intable || '_bs; threadid=_threadid_; nthreads=_nthreads_; run;';
+							fedsql.execDirect result=q / query='select max(bscount) as bss from (select count(*) as bscount from (select distinct bsID, threadid from tempholdbss) a group by threadid) b';
+							dropTable name='tempholdbss';
+							bss=q[1,1].bss;
+			end;
+			else; do;
+				bootstrap result=r / intable=intable B=B;
+				*describe(r);
+				*print r.bss;
+						/* calculate bss, can this be retrieved as response from the bootstrap action (not working) */
+						datastep.runcode result=t / code='data tempholdbss; set '|| intable || '_bs; threadid=_threadid_; nthreads=_nthreads_; run;';
+								fedsql.execDirect result=q / query='select max(bscount) as bss from (select count(*) as bscount from (select distinct bsID, threadid from tempholdbss) a group by threadid) b';
+								dropTable name='tempholdbss';
+								bss=q[1,1].bss;
+			end;
 run;
 
 		/* create a structure for the double-bootstrap sampling.
@@ -62,6 +65,12 @@ run;
                       end;
                       drop bs;
                       run;';
+run;
+
+		/*  take a look at how the table is distributed in the CAS environment */
+		datastep.runcode result=t / code='data '||intable||'_dbskey; set '||intable||'_dbskey; host=_hostname_; threadid=_threadid_; run;';
+		simple.crossTab / table={name=intable||"_dbskey" where="bag=1"} row="bsid" col="host" aggregator="N";
+		simple.crossTab / table={name=intable||"_dbskey" where="bag=1"} row="bsid" col="threadid" aggregator="N";
 run;
 
 		/* merge the double-bootstrap structure with the bootstrap structure data
@@ -90,18 +99,25 @@ run;
                       using (rowID)';
 run;
 
+		/*  take a look at how the table is distributed in the CAS environment */
+		datastep.runcode result=t / code='data '||intable||'_dbs; set '||intable||'_dbs; host=_hostname_; threadid=_threadid_; run;';
+		simple.crossTab / table={name=intable||"_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+		simple.crossTab / table={name=intable||"_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+run;
+
+		/* rebalance the table by partitioning by bsID and dbsID, this will ensure all the same values of bsID are on the same host but not necessarily the same _threadid_ */
+		partition / casout={name=intable||'_dbs', replace=TRUE} table={name=intable||'_dbs', groupby={{name='bsID'},{name='dbsID'}}};
+run;
+
+		/*  take a look at how the table is distributed in the CAS environment */
+		datastep.runcode result=t / code='data '||intable||'_dbs; set '||intable||'_dbs; host=_hostname_; threadid=_threadid_; run;';
+		simple.crossTab / table={name=intable||"_dbs" where="bag=1 and bsid=1"} row="dbsid" col="host" aggregator="N";
+		simple.crossTab / table={name=intable||"_dbs" where="bag=1 and bsid=1"} row="dbsid" col="threadid" aggregator="N";
+		alterTable / name=intable||"_dbs" columns={{name='host', drop=TRUE},{name='threadid', drop=TRUE}};
+run;
+
 		/* drop the table holding the bootstrap resampling structure */
 		dropTable name=intable||'_dbskey';
 quit;
-
-/* review the output table sample_dbs */
-proc cas;
-/*
-how many bsID
-	how many bsID per _threadid_
-how many dbsID in each
-how many rows in each dbsID (bag and OOB)
-*/
-run;
 
 *cas mysess clear;

--- a/walkthroughs/walkthrough - doubleBootstrap action.sas
+++ b/walkthroughs/walkthrough - doubleBootstrap action.sas
@@ -11,11 +11,12 @@ proc casutil;
 	load data=sashelp.cars casout="sample" replace;
 quit;
 
-/* define a parameter to hold the table name and B (the desired number of resamples, both bootstrap, and double-bootstrap)
+/* define a parameter to hold the table name and B (the desired number of resamples for the bootstrap) and D (the desired number of resamples for the double-bootstrap)
       If you are in SAS Studio use interactive mode so this will be remembered */
 proc cas;
 	 intable='sample';
 	 B=50;
+	 D=50;
 run;
 
 		/* check to see if resample.bootstrap has already been run
@@ -44,14 +45,14 @@ run;
 		          it then creates bss*nthreads resamples - double-bootstrap
 		          example: if you environment has 48 threads (maybe 3 workers with 16 threads each)
 		                    bss=10 will create 480 bootstrap resamples
-		                    each bootstrap resample will yield 480 double-bootstrap resamples
-		                    480*480 = 230,400 double-bootstrap resamples */
+		                    each bootstrap resample will yield D double-bootstrap resamples
+		                    if D=480 also then 480*480 = 230,400 double-bootstrap resamples */
     simple.numRows result=r / table=intable;
     datastep.runcode result=t / code='data '|| intable ||'_dbskey;
                         call streaminit(12345);
                       do bs = 1 to '|| bss ||';
                         bsID = (_threadid_-1)*'|| bss ||' + bs;
-                          do dbsID = 1 to '|| bss ||'*'|| q[1,1].M ||';
+                          do dbsID = 1 to '|| D ||';
                             do dbs_rowID = 1 to '|| r.numrows ||';
                               bs_rowID = int(1+'|| r.numrows ||'*rand(''Uniform''));
                               bag=1;


### PR DESCRIPTION
This primarily adds a D parameter for the doubleBootstrap action so that the user can specify how many double-bootstrap resamples to do for each bootstrap resample.  Previously these were equal.  

This handles the scenarios where a user may or may not already have run the bootstrap action on the <intable>.  If they have then it will see <intable>_bs and use it get the size of B and do the sampling.  If it does not see it then it then it will run the bootstrap action with the provided B parameter.  

In the process of making this change, it was discovered that the fedsql steps at the end of the bootstrap and doublebootstrap actions where redistributing the data so that rows for a bsID or bsID/dbsID value might be on different hosts.  Now, each action has a partition statement to take care of this.  To help understand this some diagnostic crosstabs are added to the walkthroughs and to example 1.

All walkthroughs, examples, and the readme.md are updated to reflect the changes and additions.

Many grammatical mistakes fixed, and many left for the future...